### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -3,8 +3,10 @@ cmake_minimum_required(VERSION 2.8)
 
 find_package(OpenMP REQUIRED)
 
-add_library(LIBLINEAR LibLinear/linear.cpp LibLinear/linear.h LibLinear/train.c LibLinear/tron.cpp LibLinear/tron.h)
-add_library(BLAS LibLinear/blas/blas.h LibLinear/blas/blasp.h LibLinear/blas/daxpy.c LibLinear/blas/ddot.c LibLinear/blas/dnrm2.c LibLinear/blas/dscal.c)
+# compile LibLinear
+include_directories("LibLinear")
+file(GLOB SOURCES "LibLinear/*.cpp" "LibLinear/blas/*.c")
+add_library(LibLinear STATIC ${SOURCES})
 
 #OPENCV
 #include_directories(/usr/local/include)
@@ -17,10 +19,12 @@ endif( OpenCV_FOUND )
 list( APPEND CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS} -fopenmp -ftree-vectorize")
 #list( APPEND CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS} -fopenmp -ftest-coverage -fprofile-arcs")
 
-add_executable(${PROJECT_NAME} main.cpp CmShow.h CmShow.cpp kyheader.h kyheader.cpp CmFile.h CmFile.cpp CmTimer.h
-FilterTIG.h FilterTIG.cpp DataSetVOC.cpp DataSetVOC.h ImgContrastBB.h Objectness.cpp Objectness.h ValStructVec.h
-LibLinear/linear.h LibLinear/linear.cpp LibLinear/tron.h LibLinear/tron.cpp LibLinear/blas/blas.h LibLinear/blas/blasp.h
-LibLinear/blas/daxpy.c LibLinear/blas/ddot.c LibLinear/blas/dnrm2.c LibLinear/blas/dscal.c)
+# compile BING
+file(GLOB SOURCES "*.cpp")
+add_library(BING STATIC ${SOURCES})
+
+add_executable(${PROJECT_NAME} main.cpp)
+
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall")
-target_link_libraries(BING_linux opencv_core opencv_imgproc opencv_highgui ${EXTERNAL_LIBS})
+target_link_libraries(${PROJECT_NAME} opencv_core opencv_imgproc opencv_highgui opencv_imgcodecs ${EXTERNAL_LIBS} BING LibLinear)


### PR DESCRIPTION
- add `opencv_imgcodecs` to `target_link_libraries` for OpenCV 3.0 
  - fixing error:
```
    /usr/bin/ld: libBING.a(Objectness.cpp.o): undefined reference to symbol     '_ZN2cv7imwriteERKNS_6StringERKNS_11_InputArrayERKSt6vectorIiSaIiEE'
    /usr/local/lib/libopencv_imgcodecs.so.3.0: error adding symbols: DSO missing from command line
```

- re-organize library compile order 
  - previously the `LibLinear` was compiled as library but not used; the `BING` was not considered as library
  - now `LibLinear` and `BING` are compiled as libraries and linked to a single `main.cpp`